### PR TITLE
 bugfix/22553/add-ntp-servers-configured-in-the-platformAdd ntp servers from sensor role

### DIFF
--- a/resources/templates/default/chrony.conf.erb
+++ b/resources/templates/default/chrony.conf.erb
@@ -8,11 +8,15 @@ cmdallow 0.0.0.0/0
   <% end -%>
 <% end -%>
 
-<% if (node[:redborder] && node[:redborder][:ntp] && node[:redborder][:ntp][:is_server]) or Chrony::Helpers.contains_role("proxy", node) or Chrony::Helpers.contains_role("ipscp", node) -%>
-  <% @servers.each do |ntpserver| -%>
+<% ntp_servers = (node['redborder'] && node['redborder']['ntp'] && node['redborder']['ntp']['servers']) || @servers -%>
+
+<% if ntp_servers && !ntp_servers.empty? -%>
+  <% ntp_servers.each do |ntpserver| -%>
 server <%= ntpserver %> iburst
   <% end -%>
+  <% if (node[:redborder] && node[:redborder][:ntp] && node[:redborder][:ntp][:is_server]) or Chrony::Helpers.contains_role("proxy", node) or Chrony::Helpers.contains_role("ipscp", node) -%>
 allow 0.0.0.0/0
+  <% end -%>
 <% end -%>
 
 <% if !node[:redborder][:is_sensor] and (!Chrony::Helpers.contains_role("proxy", node) and !Chrony::Helpers.contains_role("ipscp", node)) -%>


### PR DESCRIPTION
## Related issue in RedMine

[bug#22553 add ntp servers configured in the platform](https://redmine.redborder.lan/issues/22553)

## Description / Motivation

the ntp servers configured in the platform (general settings) are not applied in the proxy and ips sensors. The default ntp servers are always applied
In case the sensors are out of the network, there should be a possibility to overrule them on the level of the sensor (ips and proxy)

## Detail

In case node hasn't attribute, use propagated NTP servers to sensor's role with cookbook-rb-manager
